### PR TITLE
Added pytest decorator

### DIFF
--- a/robozilla/decorators/__init__.py
+++ b/robozilla/decorators/__init__.py
@@ -494,8 +494,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
 def pytest_skip_if_bug_open(bug_type, bug_id, sat_version_picker=None,
                             config_picker=None):
     """Pytest parametrized tests can't work with the default `skip_if_bug_open`
-    this decorator returns a propoer Pytest.mark which can work with that
-    scenario.
+    this decorator returns a Pytest.mark which can work with that scenario.
     """
     return pytest.mark.skipif(
         (bz_bug_is_open if bug_type == 'bugzilla' else rm_bug_is_open)(

--- a/robozilla/decorators/__init__.py
+++ b/robozilla/decorators/__init__.py
@@ -495,6 +495,42 @@ def pytest_skip_if_bug_open(bug_type, bug_id, sat_version_picker=None,
                             config_picker=None):
     """Pytest parametrized tests can't work with the default `skip_if_bug_open`
     this decorator returns a Pytest.mark which can work with that scenario.
+
+    Example:
+
+        @pytest_skip_if_bug_open(
+            'bugzilla', 1079482,
+            sat_version_picker=lambda: '6.2.10',
+            config_picker=lambda: {
+                'bz_credentials': {'user': '', 'password': ''}
+            }
+        )
+        @pytest.mark.parametrize("foo,bar", [('1', '2')], ids=['foo and bar'])
+        def test_something(foo, bar):
+            assert ....
+
+    Or make it a partial function:
+
+        from functools import partial
+        pytest_skip_if_bug_open = partial(
+            pytest_skip_if_bug_open,
+            sat_version_picker=a_function_returning_version,
+            config_picker=a_function_returning_config_dict
+        )
+
+    Then use as usual:
+
+        @pytest_skip_if_bug_open('bugzilla', 1079482)
+        @pytest.mark.parametrize("foo,bar", [('1', '2')], ids=['foo and bar'])
+        def test(foo, bar):
+            ...
+
+    :param str bug_type: Either 'bugzilla' or 'redmine'.
+    :param int bug_id: The ID of the bug to check when the decorator isrun.
+    :param sat_version_picker: a callable returning 'x.y.z'
+    :param config_picker: a callable returning a dictionary optionally with
+        {'bz_credentials': {'user': '', 'password': ''}}
+
     """
     return pytest.mark.skipif(
         (bz_bug_is_open if bug_type == 'bugzilla' else rm_bug_is_open)(

--- a/robozilla/scan.py
+++ b/robozilla/scan.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import os
 import json
 
@@ -196,6 +195,7 @@ def coverage(exclude_components, include_flags, exclude_flags, start_date,
             bz_query = BZQuery(**reader_options)
             bugs = bz_query.query(**query)
             print("{} = {}".format(coverage_type, len(bugs)))
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = []
 
 setup(
     name='robozilla',
-    version='0.1.9',
+    version='0.2.0',
     packages=packages,
     url='https://github.com/ldjebran/robozilla',
     license='GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
Added a special decorator to work with parametrized tests as the general decorator can't work with that scenario.

```python
import pytest
from robozilla.decorators import pytest_skip_if_bug_open

@pytest.mark.parametrize(
    "pre,post",
    [('a', 'a'), ('b', 'b')],
    ids=['pre and post', 'foo and bar']
)
@pytest_skip_if_bug_open('bugzilla', 1079482)
# ^ pass `sat_version_picker` and `config_picker` for authenticated calls
def test_param_with_bz_dec(pre, post):
    """Test parametrized test with bz decorator"""
    assert pre == post
```

test:
```bash
2017-09-18 09:23:05 - robozilla.decorators - INFO - Bugzilla bug 1079482 not in cache. Fetching.
2017-09-18 09:23:15 - robozilla.decorators - DEBUG - Bugzilla 1079482 is open
collected 2 items 
test_param_with_bz_dec[pre and post] SKIPPED
test_param_with_bz_dec[foo and bar] SKIPPED
=======================short test summary info =======================
SKIP [2] :57: Skipping due to bugzilla 1079482
```

+ 2 PEP8 issues

```bash
robozilla/scan.py:1:1: F401 'collections.OrderedDict' imported but unused
robozilla/scan.py:200:1: E305 expected 2 blank lines after class or function definition, found 1
```