### PR TITLE
Ignore BZ clones for different versions of satellite if there's a clone for current one

### DIFF
--- a/robozilla/decorators/__init__.py
+++ b/robozilla/decorators/__init__.py
@@ -280,14 +280,15 @@ def _check_skip_conditions_for_bug_and_clones(bug, consider_flags=True,
             return set(zstream_versions+downstream_versions)
 
         affected_clone_present = any(
-            float(sat_version_picker()) in get_bug_versions(bug)
-            for bug in filtered_bugs
+            float(sat_version_picker()) in get_bug_versions(bug_or_clone)
+            for bug_or_clone in filtered_bugs
         )
         if affected_clone_present:
             # remove not actual bugs from list
             filtered_bugs = [
-                bug for bug in filtered_bugs
-                if float(sat_version_picker()) in get_bug_versions(bug)
+                bug_or_clone for bug_or_clone in filtered_bugs
+                if float(sat_version_picker()) in get_bug_versions(
+                    bug_or_clone)
             ]
 
     skip_results = (


### PR DESCRIPTION
Currently we have 1 BZ which was fixed in 6.2.z and a clone for 6.3 was created to port the changes. With current logic robozilla assumes if BZ was fixed in 6.2.z -> it's fixed for 6.3, which is incorrect as we have 6.3 clone open.
This change will make robozilla consider the status of BZ for matching version of satellite.

Regarding test results  - i wrote simple test smth like:
```python
class FooTestCase(CLITestCase):

    def test_foo(self):
        from robottelo.bz_helpers import get_decorated_bugs
        from robozilla.decorators import bz_bug_is_open
        bugs_list = get_decorated_bugs()
        result = set([
            (bug['bug_id'],
             bz_bug_is_open(
                 bug['bug_id'],
                 lambda: '6.3',
                 lambda: {'bz_credentials': {
                     'user': 'login@example.com',
                     'password': 'password'}})
             )
            for bug in bugs_list.values()
        ])

        with open('output.txt', 'w') as f:
            f.write(repr(result))
```
And compared results before and after the change:
```python
In [10]: after.difference(before)
Out[10]: {('1480358', True)}
```
So the only BZ which was affected by this change is 1480358 (expected one). I've also run all robotello's BZ tests and they're passing:
```
pytest tests/robottelo/test_decorators.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 51 items

tests/robottelo/test_decorators.py ...................................................

========================== 51 passed in 0.41 seconds ===========================
```
So any existing scenario shouldn't be affected (i'll rise a PR to robottelo to test this scenario in a few).