### PR TITLE
HOTFIXES 0.2.6

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,12 @@
 History
 =======
 
+0.2.6 (2018-01-04)
+------------------
+* HOTFIXES
+* Consider `6.x` (two digit) version on _extract_version as it is being used for tests
+* Revert change on skip_upstream_condition to look straightly to CLOSED status 
+
 0.2.5 (2018-01-03)
 ------------------
 * Follow DUPLICATE status if BZ is CLOSED DUPLICATE 

--- a/robozilla/decorators/__init__.py
+++ b/robozilla/decorators/__init__.py
@@ -15,7 +15,6 @@ from robozilla.constants import (
     BUGZILLA_ENVIRON_SAT_VERSION,
     BUGZILLA_ENVIRON_USER_NAME,
     BUGZILLA_ENVIRON_USER_PASSWORD_NAME,
-    BZ_CLOSED_STATUSES,
     BZ_OPEN_STATUSES,
     REDMINE_URL
 )
@@ -141,9 +140,13 @@ def _extract_version(regular_exp, possible_version):
     :param regular_exp: A `re.compile` instance
     :param possible_version: The string in the form sat-x.x.x or x.x.x
     """
-    result = regular_exp.search(possible_version)
-    if result:
-        return float(result.group('version'))
+    try:
+        # EAFP to get a float direct from `6.1` like strings before regexing
+        return float(possible_version.strip())
+    except ValueError:
+        result = regular_exp.search(possible_version)
+        if result:
+            return float(result.group('version'))
 
 
 # To get specifically the .z version as in sat-6.2.z
@@ -241,7 +244,7 @@ def _check_skip_condition_for_one_bug(bug, consider_flags,
          Verify all conditions are True, stopping evaluation when
          first condition is False
         """
-        yield bug['status'] not in BZ_CLOSED_STATUSES
+        yield bug['status'] != 'CLOSED'
         whiteboard = bug.get('whiteboard', '')
         yield whiteboard
         yield 'verified in upstream' in whiteboard.lower()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = []
 
 setup(
     name='robozilla',
-    version='0.2.5',
+    version='0.2.6',
     packages=packages,
     url='https://github.com/ldjebran/robozilla',
     license='GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
* Consider `6.x` (two digit) version on _extract_version as it is being used for tests
On BugZilla versions are in form `sat-6.x.x` but on robottelo tests we can pass two digit `6.x` so it should be considered on _extract_version function.

* Revert change on skip_upstream_condition to look straightly to CLOSED status
Strict follow the "do not test bugs with whiteboard 'verified in upstream' in
        downstream until they are in 'CLOSED' state"