### PR TITLE
Removed unittest with pytest skip

### DIFF
--- a/robozilla/decorators/__init__.py
+++ b/robozilla/decorators/__init__.py
@@ -8,7 +8,6 @@ from itertools import chain
 
 import pytest
 import requests
-import unittest2
 
 from robozilla.bz import BZReader
 from robozilla.constants import (
@@ -560,7 +559,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
                     func.__module__,
                     self.bug_id
                 )
-                raise unittest2.SkipTest(
+                pytest.skip(
                     'Skipping test due to open Bugzilla bug #{0}.'
                     ''.format(self.bug_id)
                 )
@@ -571,7 +570,7 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
                     func.__module__,
                     self.bug_id
                 )
-                raise unittest2.SkipTest(
+                pytest.skip(
                     'Skipping test due to open Redmine bug #{0}.'
                     ''.format(self.bug_id)
                 )


### PR DESCRIPTION
Fixes the upgrade existance tests failing with unittest issue on Python 3.11:
```
20:22:18  upgrade_tests/test_existance_relations/cli/test_activationkeys.py:22: in <module>
20:22:18      from upgrade_tests.helpers.common import existence
20:22:18  upgrade_tests/helpers/common.py:7: in <module>
20:22:18      from robozilla.decorators import pytest_skip_if_bug_open
20:22:18  ../../lib64/python3.11/site-packages/robozilla/decorators/__init__.py:11: in <module>
20:22:18      import unittest2
20:22:18  ../../lib64/python3.11/site-packages/unittest2/__init__.py:40: in <module>
20:22:18      from unittest2.collector import collector
20:22:18  ../../lib64/python3.11/site-packages/unittest2/collector.py:3: in <module>
20:22:18      from unittest2.loader import defaultTestLoader
20:22:18  ../../lib64/python3.11/site-packages/unittest2/loader.py:13: in <module>
20:22:18      from unittest2 import case, suite, util
20:22:18  ../../lib64/python3.11/site-packages/unittest2/case.py:18: in <module>
20:22:18      from unittest2 import result
20:22:18  ../../lib64/python3.11/site-packages/unittest2/result.py:10: in <module>
20:22:18      from unittest2.compatibility import wraps
20:22:18  ../../lib64/python3.11/site-packages/unittest2/compatibility.py:143: in <module>
20:22:18      class ChainMap(collections.MutableMapping):
20:22:18  E   AttributeError: module 'collections' has no attribute 'MutableMapping'
```